### PR TITLE
link both canonical urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
 <meta property=twitter:image:alt content="rad volume bars">
 
 <link rel=stylesheet href=wall.css>
+<link rel=canonical href="https://webmural.com/beabadoobee">
 <link rel=canonical href="https://webmural.github.io/beabadoobee">
 <link data-code rel=license href="https://creativecommons.org/publicdomain/zero/1.0">
 <link data-page rel=license href="https://creativecommons.org/licenses/by/4.0">


### PR DESCRIPTION
Currently [webmural.com](https://webmural.com) redirects to [webmural.github.io](https://webmural.github.io)